### PR TITLE
Bring up to date with Jenkins 2.x

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins
+FROM jenkins:2.7.1
 
 # Assume root privs
 USER root

--- a/jenkinssetup/Dockerfile
+++ b/jenkinssetup/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:trusty
 RUN apt-get update -y && apt-get install -y git python python-pip python-yaml curl socat default-jdk wget telnet
 RUN pip install setuptools PyYAML python-jenkins ordereddict jenkinsapi
 WORKDIR /jenkins_setup

--- a/jenkinssetup/credentials/jenkins_credentials.sh
+++ b/jenkinssetup/credentials/jenkins_credentials.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-curl -XPOST 'jenkins:8080/credential-store/domain/_/createCredentials' \
+curl -XPOST 'jenkins:8080/credentials/store/system/domain/_/createCredentials' \
     --data-urlencode 'json={
         "": "0", 
         "credentials": {

--- a/jenkinssetup/startup.sh
+++ b/jenkinssetup/startup.sh
@@ -17,14 +17,6 @@ function restart_and_wait_for_jenkins() {
 
 wait_for_jenkins
 
-# Set up credentials
-echo Setting up credentials
-pushd credentials
-./jenkins_credentials.sh
-python jenkins_credentials.py
-popd
-echo Setting up credentials complete
-
 # Set up plugins. Restart until complete
 # do a while loop waiting for confirmed installation
 echo Plugin install started
@@ -46,6 +38,14 @@ done
 restart_and_wait_for_jenkins
 popd
 echo Plugin install complete
+
+# Set up credentials
+echo Setting up credentials
+pushd credentials
+./jenkins_credentials.sh
+python jenkins_credentials.py
+popd
+echo Setting up credentials complete
 
 echo Set up nodes
 pushd nodes

--- a/jenkinsswarmslave1/Dockerfile
+++ b/jenkinsswarmslave1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:trusty
 RUN groupadd -g 1000 jenkins
 RUN useradd -d /home/jenkins -s /bin/bash -m jenkins -u 1000 -g jenkins
 RUN echo jenkins:jpass | chpasswd

--- a/jenkinsswarmslave1/startup.sh
+++ b/jenkinsswarmslave1/startup.sh
@@ -10,5 +10,5 @@ echo "$@"
 echo "and env:"
 echo "$(env)"
 set -x
-java -jar /home/jenkins/swarm-client-1.22-jar-with-dependencies.jar -fsroot "$SLAVE_JENKINS_HOME" -labels "$SLAVE_JENKINS_LABELS" -master http://$SLAVE_JENKINS_SERVER:$SLAVE_JENKINS_PORT $@
+java -jar /home/jenkins/swarm-client-1.22-jar-with-dependencies.jar -name jenkinsswarmslave1 -fsroot "$SLAVE_JENKINS_HOME" -labels "$SLAVE_JENKINS_LABELS" -master http://$SLAVE_JENKINS_SERVER:$SLAVE_JENKINS_PORT $@
 sleep infinity


### PR DESCRIPTION
Jenkins 1.x was end-of-lifed early in July 2016, so may as well bring jenkins-phoenix up to Jenkins 2.x:
- One of the plugins jenkins-phoenix uses has a dependency on the Credentials Plugin. The latter has been updated to use Jenkins 2.x's new credentials URL, so there is a need to update the URL in credentials.sh.
  - In addition, reversing the order of installing plugins and setting up credentials avoids getting mixed up between old and new URL.
- Using a base image of "ubuntu" (implying "latest") would bring in version 16.04. This version has a problem with openjdk-7-jre when doing an apt-get install. Pinning ubuntu to "trusty" solved this.

And while I was in there, I gave a meaningful name to the jenkinswarmslave1 node.
